### PR TITLE
Adjust paddings to show NeumorphButton with drawable properly (#27)

### DIFF
--- a/neumorphism/src/main/res/values/styles.xml
+++ b/neumorphism/src/main/res/values/styles.xml
@@ -5,11 +5,14 @@
 
     <style name="Widget.Neumorph" />
 
-    <style name="Widget.Neumorph.Button" parent="android:Widget">
-        <item name="android:padding">@dimen/design_default_padding</item>
+    <style name="Widget.Neumorph.Button" parent="Widget.AppCompat.Button">
         <item name="android:textAppearance">?android:attr/textAppearanceButton</item>
         <item name="android:minHeight">72dip</item>
         <item name="android:minWidth">112dip</item>
+        <item name="android:paddingLeft">@dimen/design_btn_padding_left</item>
+        <item name="android:paddingRight">@dimen/design_btn_padding_right</item>
+        <item name="android:paddingTop">@dimen/design_btn_padding_top</item>
+        <item name="android:paddingBottom">@dimen/design_btn_padding_bottom</item>
         <item name="android:stateListAnimator">@animator/button_state_list_anim_neumorph</item>
         <item name="android:focusable">true</item>
         <item name="android:clickable">true</item>

--- a/neumorphism/src/main/res/values/values.xml
+++ b/neumorphism/src/main/res/values/values.xml
@@ -10,6 +10,10 @@
 
     <!-- Default padding and inset to avoid shadow clipping -->
     <dimen name="design_default_padding">12dp</dimen>
+    <dimen name="design_btn_padding_left">32dp</dimen>
+    <dimen name="design_btn_padding_right">32dp</dimen>
+    <dimen name="design_btn_padding_top">12dp</dimen>
+    <dimen name="design_btn_padding_bottom">12dp</dimen>
     <dimen name="design_default_inset">12dp</dimen>
 
     <!-- Default corner radius -->

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -26,7 +26,7 @@ android {
 dependencies {
     implementation project(":neumorphism")
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.core:core-ktx:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.core:core-ktx:1.3.1'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 }

--- a/sample/src/main/res/drawable/ic_left.xml
+++ b/sample/src/main/res/drawable/ic_left.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?colorAccent"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M14.71,6.71c-0.39,-0.39 -1.02,-0.39 -1.41,0L8.71,11.3c-0.39,0.39 -0.39,1.02 0,1.41l4.59,4.59c0.39,0.39 1.02,0.39 1.41,0 0.39,-0.39 0.39,-1.02 0,-1.41L10.83,12l3.88,-3.88c0.39,-0.39 0.38,-1.03 0,-1.41z" />
+</vector>

--- a/sample/src/main/res/drawable/ic_right.xml
+++ b/sample/src/main/res/drawable/ic_right.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?colorAccent"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M9.29,6.71c-0.39,0.39 -0.39,1.02 0,1.41L13.17,12l-3.88,3.88c-0.39,0.39 -0.39,1.02 0,1.41 0.39,0.39 1.02,0.39 1.41,0l4.59,-4.59c0.39,-0.39 0.39,-1.02 0,-1.41L10.7,6.7c-0.38,-0.38 -1.02,-0.38 -1.41,0.01z" />
+</vector>

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -115,7 +115,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="36dp"
+        android:drawablePadding="8dp"
         android:text="Button"
+        app:drawableStartCompat="@drawable/ic_left"
+        app:drawableEndCompat="@drawable/ic_right"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />

--- a/sample/src/main/res/layout/activity_sample_card.xml
+++ b/sample/src/main/res/layout/activity_sample_card.xml
@@ -56,7 +56,7 @@
 
             <soup.neumorphism.NeumorphButton
                 android:id="@+id/button"
-                android:layout_width="150dp"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_margin="8dp"
                 android:text="Learn more"


### PR DESCRIPTION
- #27
- NeumorphButton extends AppCompatButton.
  So the button already has the ability to show an icon.
  Please refer to the following codes.

```kt
<soup.neumorphism.NeumorphButton
    android:drawablePadding="8dp"
    app:drawableStartCompat="@drawable/ic_left"
    app:drawableEndCompat="@drawable/ic_right" />
```

Before | After
-- | --
<img width="300" src="https://user-images.githubusercontent.com/3405740/90112042-77999280-dd8a-11ea-9d17-0491040b7e5c.png" /> | <img width="300" src="https://user-images.githubusercontent.com/3405740/90112021-6badd080-dd8a-11ea-9069-c9fcb0523925.png" />