### PR TITLE
Library: Use different blur radius as device density (#31)

### DIFF
--- a/neumorphism/src/main/java/soup/neumorphism/internal/blur/BlurFactor.kt
+++ b/neumorphism/src/main/java/soup/neumorphism/internal/blur/BlurFactor.kt
@@ -5,12 +5,12 @@ import android.graphics.Color
 internal data class BlurFactor(
     val width: Int,
     val height: Int,
-    val radius: Int = DEFAULT_RADIUS,
+    val radius: Int = MAX_RADIUS,
     val sampling: Int = DEFAULT_SAMPLING,
     val color: Int = Color.TRANSPARENT
 ) {
     companion object {
-        const val DEFAULT_RADIUS = 25
+        const val MAX_RADIUS = 25
         const val DEFAULT_SAMPLING = 1
     }
 }

--- a/neumorphism/src/main/java/soup/neumorphism/internal/blur/BlurProvider.kt
+++ b/neumorphism/src/main/java/soup/neumorphism/internal/blur/BlurProvider.kt
@@ -5,19 +5,32 @@ import android.graphics.Bitmap
 import android.graphics.Paint
 import android.graphics.PorterDuff
 import android.graphics.PorterDuffColorFilter
+import android.os.Build
 import android.renderscript.*
+import android.util.DisplayMetrics
 import soup.neumorphism.internal.util.onCanvas
 import java.lang.ref.WeakReference
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.math.roundToInt
 
 internal class BlurProvider(context: Context) {
 
     private val contextRef = WeakReference(context)
+    private val defaultBlurRadius: Int
+
+    init {
+        val densityStable = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            DisplayMetrics.DENSITY_DEVICE_STABLE / DisplayMetrics.DENSITY_DEFAULT.toFloat()
+        } else {
+            context.resources.displayMetrics.density
+        }
+        defaultBlurRadius = min(BlurFactor.MAX_RADIUS, (densityStable * 10).roundToInt())
+    }
 
     fun blur(
         source: Bitmap,
-        radius: Int = BlurFactor.DEFAULT_RADIUS,
+        radius: Int = defaultBlurRadius,
         sampling: Int = BlurFactor.DEFAULT_SAMPLING
     ): Bitmap? {
         val factor = BlurFactor(


### PR DESCRIPTION
- #31

## mdpi

Before | After
-- | --
<img width="300" src="https://user-images.githubusercontent.com/3405740/90146451-05da3c80-ddbc-11ea-95fa-f0e360cecd60.png" /> | <img width="300" src="https://user-images.githubusercontent.com/3405740/90146433-0246b580-ddbc-11ea-998d-f9c2bd1de7a1.png" />

## ldpi

Before | After
-- | --
<img src="https://user-images.githubusercontent.com/3405740/90146490-0f63a480-ddbc-11ea-9b0f-57258732f96a.png" /> | <img src="https://user-images.githubusercontent.com/3405740/90146489-0ecb0e00-ddbc-11ea-8871-3ff9e9b5a28e.png" />
