### PR TITLE
New Feature: added background drawable support to all current components

### DIFF
--- a/neumorphism/src/main/java/soup/neumorphism/NeumorphButton.kt
+++ b/neumorphism/src/main/java/soup/neumorphism/NeumorphButton.kt
@@ -28,6 +28,7 @@ class NeumorphButton @JvmOverloads constructor(
         val a = context.obtainStyledAttributes(
             attrs, R.styleable.NeumorphButton, defStyleAttr, defStyleRes
         )
+        val backgroundDrawable = a.getDrawable(R.styleable.NeumorphImageButton_neumorph_backgroundDrawable)
         val fillColor = a.getColorStateList(R.styleable.NeumorphButton_neumorph_backgroundColor)
         val strokeColor = a.getColorStateList(R.styleable.NeumorphButton_neumorph_strokeColor)
         val strokeWidth = a.getDimension(R.styleable.NeumorphButton_neumorph_strokeWidth, 0f)
@@ -68,6 +69,7 @@ class NeumorphButton @JvmOverloads constructor(
             setShadowElevation(shadowElevation)
             setShadowColorLight(shadowColorLight)
             setShadowColorDark(shadowColorDark)
+            setBackgroundDrawable(backgroundDrawable)
             setFillColor(fillColor)
             setStroke(strokeWidth, strokeColor)
             setTranslationZ(translationZ)
@@ -87,7 +89,7 @@ class NeumorphButton @JvmOverloads constructor(
     }
 
     override fun setBackgroundDrawable(drawable: Drawable?) {
-        Log.i(LOG_TAG, "Setting a custom background is not supported.")
+        shapeDrawable.setBackgroundDrawable(drawable)
     }
 
     private fun setBackgroundInternal(drawable: Drawable?) {

--- a/neumorphism/src/main/java/soup/neumorphism/NeumorphCardView.kt
+++ b/neumorphism/src/main/java/soup/neumorphism/NeumorphCardView.kt
@@ -30,6 +30,7 @@ class NeumorphCardView @JvmOverloads constructor(
         val a = context.obtainStyledAttributes(
             attrs, R.styleable.NeumorphCardView, defStyleAttr, defStyleRes
         )
+        val backgroundDrawable = a.getDrawable(R.styleable.NeumorphImageButton_neumorph_backgroundDrawable)
         val fillColor = a.getColorStateList(R.styleable.NeumorphCardView_neumorph_backgroundColor)
         val strokeColor = a.getColorStateList(R.styleable.NeumorphCardView_neumorph_strokeColor)
         val strokeWidth = a.getDimension(R.styleable.NeumorphCardView_neumorph_strokeWidth, 0f)
@@ -70,6 +71,7 @@ class NeumorphCardView @JvmOverloads constructor(
             setShadowElevation(shadowElevation)
             setShadowColorLight(shadowColorLight)
             setShadowColorDark(shadowColorDark)
+            setBackgroundDrawable(backgroundDrawable)
             setFillColor(fillColor)
             setStroke(strokeWidth, strokeColor)
             setTranslationZ(translationZ)
@@ -100,7 +102,7 @@ class NeumorphCardView @JvmOverloads constructor(
     }
 
     override fun setBackgroundDrawable(drawable: Drawable?) {
-        Log.i(LOG_TAG, "Setting a custom background is not supported.")
+        shapeDrawable.setBackgroundDrawable(drawable)
     }
 
     private fun setBackgroundInternal(drawable: Drawable?) {

--- a/neumorphism/src/main/java/soup/neumorphism/NeumorphFloatingActionButton.kt
+++ b/neumorphism/src/main/java/soup/neumorphism/NeumorphFloatingActionButton.kt
@@ -28,6 +28,8 @@ class NeumorphFloatingActionButton @JvmOverloads constructor(
         val a = context.obtainStyledAttributes(
             attrs, R.styleable.NeumorphFloatingActionButton, defStyleAttr, defStyleRes
         )
+
+        val backgroundDrawable = a.getDrawable(R.styleable.NeumorphImageButton_neumorph_backgroundDrawable)
         val fillColor = a.getColorStateList(R.styleable.NeumorphFloatingActionButton_neumorph_backgroundColor)
         val strokeColor = a.getColorStateList(R.styleable.NeumorphFloatingActionButton_neumorph_strokeColor)
         val strokeWidth = a.getDimension(R.styleable.NeumorphFloatingActionButton_neumorph_strokeWidth, 0f)
@@ -69,6 +71,7 @@ class NeumorphFloatingActionButton @JvmOverloads constructor(
             setShadowElevation(shadowElevation)
             setShadowColorLight(shadowColorLight)
             setShadowColorDark(shadowColorDark)
+            setBackgroundDrawable(backgroundDrawable)
             setFillColor(fillColor)
             setStroke(strokeWidth, strokeColor)
             setTranslationZ(translationZ)
@@ -88,7 +91,7 @@ class NeumorphFloatingActionButton @JvmOverloads constructor(
     }
 
     override fun setBackgroundDrawable(drawable: Drawable?) {
-        Log.i(LOG_TAG, "Setting a custom background is not supported.")
+        shapeDrawable.setBackgroundDrawable(drawable)
     }
 
     private fun setBackgroundInternal(drawable: Drawable?) {

--- a/neumorphism/src/main/java/soup/neumorphism/NeumorphImageButton.kt
+++ b/neumorphism/src/main/java/soup/neumorphism/NeumorphImageButton.kt
@@ -28,6 +28,8 @@ class NeumorphImageButton @JvmOverloads constructor(
         val a = context.obtainStyledAttributes(
             attrs, R.styleable.NeumorphImageButton, defStyleAttr, defStyleRes
         )
+
+        val backgroundDrawable = a.getDrawable(R.styleable.NeumorphImageButton_neumorph_backgroundDrawable)
         val fillColor = a.getColorStateList(R.styleable.NeumorphImageButton_neumorph_backgroundColor)
         val strokeColor = a.getColorStateList(R.styleable.NeumorphImageButton_neumorph_strokeColor)
         val strokeWidth = a.getDimension(R.styleable.NeumorphImageButton_neumorph_strokeWidth, 0f)
@@ -68,10 +70,12 @@ class NeumorphImageButton @JvmOverloads constructor(
             setShadowElevation(shadowElevation)
             setShadowColorLight(shadowColorLight)
             setShadowColorDark(shadowColorDark)
+            setBackgroundDrawable(backgroundDrawable)
             setFillColor(fillColor)
             setStroke(strokeWidth, strokeColor)
             setTranslationZ(translationZ)
         }
+
         internalSetInset(
             if (insetStart >= 0) insetStart else inset,
             if (insetTop >= 0) insetTop else inset,
@@ -87,7 +91,7 @@ class NeumorphImageButton @JvmOverloads constructor(
     }
 
     override fun setBackgroundDrawable(drawable: Drawable?) {
-        Log.i(LOG_TAG, "Setting a custom background is not supported.")
+        shapeDrawable.setBackgroundDrawable(drawable)
     }
 
     private fun setBackgroundInternal(drawable: Drawable?) {

--- a/neumorphism/src/main/java/soup/neumorphism/NeumorphImageView.kt
+++ b/neumorphism/src/main/java/soup/neumorphism/NeumorphImageView.kt
@@ -28,6 +28,8 @@ class NeumorphImageView @JvmOverloads constructor(
         val a = context.obtainStyledAttributes(
             attrs, R.styleable.NeumorphImageView, defStyleAttr, defStyleRes
         )
+
+        val backgroundDrawable = a.getDrawable(R.styleable.NeumorphImageButton_neumorph_backgroundDrawable)
         val fillColor = a.getColorStateList(R.styleable.NeumorphImageView_neumorph_backgroundColor)
         val strokeColor = a.getColorStateList(R.styleable.NeumorphImageView_neumorph_strokeColor)
         val strokeWidth = a.getDimension(R.styleable.NeumorphImageView_neumorph_strokeWidth, 0f)
@@ -68,6 +70,7 @@ class NeumorphImageView @JvmOverloads constructor(
             setShadowElevation(shadowElevation)
             setShadowColorLight(shadowColorLight)
             setShadowColorDark(shadowColorDark)
+            setBackgroundDrawable(backgroundDrawable)
             setFillColor(fillColor)
             setStroke(strokeWidth, strokeColor)
             setTranslationZ(translationZ)
@@ -87,7 +90,7 @@ class NeumorphImageView @JvmOverloads constructor(
     }
 
     override fun setBackgroundDrawable(drawable: Drawable?) {
-        Log.i(LOG_TAG, "Setting a custom background is not supported.")
+        shapeDrawable.setBackgroundDrawable(drawable)
     }
 
     private fun setBackgroundInternal(drawable: Drawable?) {

--- a/neumorphism/src/main/java/soup/neumorphism/NeumorphShapeDrawable.kt
+++ b/neumorphism/src/main/java/soup/neumorphism/NeumorphShapeDrawable.kt
@@ -13,6 +13,9 @@ import soup.neumorphism.internal.shape.BasinShape
 import soup.neumorphism.internal.shape.FlatShape
 import soup.neumorphism.internal.shape.PressedShape
 import soup.neumorphism.internal.shape.Shape
+import soup.neumorphism.internal.util.BitmapUtils.clipToPath
+import soup.neumorphism.internal.util.BitmapUtils.clipToRadius
+
 
 class NeumorphShapeDrawable : Drawable {
 
@@ -24,6 +27,7 @@ class NeumorphShapeDrawable : Drawable {
         style = Paint.Style.FILL
         color = Color.TRANSPARENT
     }
+
     private val strokePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
         style = Paint.Style.STROKE
         color = Color.TRANSPARENT
@@ -86,6 +90,15 @@ class NeumorphShapeDrawable : Drawable {
 
     fun getShapeAppearanceModel(): NeumorphShapeAppearanceModel {
         return drawableState.shapeAppearanceModel
+    }
+
+    fun setBackgroundDrawable(drawable: Drawable?) {
+        this.drawableState.backgroundDrawable = drawable
+        invalidateSelf()
+    }
+
+    fun getBackgroundDrawable(): Drawable? {
+        return this.drawableState.backgroundDrawable
     }
 
     fun setFillColor(fillColor: ColorStateList?) {
@@ -241,6 +254,10 @@ class NeumorphShapeDrawable : Drawable {
         invalidateSelfIgnoreShape()
     }
 
+    private fun hasBackgroundDrawable(): Boolean {
+        return drawableState.backgroundDrawable?.let(Drawable::isVisible) ?: false
+    }
+
     private fun hasFill(): Boolean {
         return (drawableState.paintStyle === Paint.Style.FILL_AND_STROKE
                 || drawableState.paintStyle === Paint.Style.FILL)
@@ -258,8 +275,11 @@ class NeumorphShapeDrawable : Drawable {
     }
 
     override fun draw(canvas: Canvas) {
-        val prevAlpha = fillPaint.alpha
-        fillPaint.alpha = modulateAlpha(prevAlpha, drawableState.alpha)
+        val prevBackgroundAlpha = drawableState.backgroundDrawable?.alpha ?: 0
+        drawableState.backgroundDrawable?.alpha = modulateAlpha(prevBackgroundAlpha, drawableState.alpha)
+
+        val prevFillAlpha = fillPaint.alpha
+        fillPaint.alpha = modulateAlpha(prevFillAlpha, drawableState.alpha)
 
         strokePaint.strokeWidth = drawableState.strokeWidth
         val prevStrokeAlpha = strokePaint.alpha
@@ -275,14 +295,40 @@ class NeumorphShapeDrawable : Drawable {
             drawFillShape(canvas)
         }
 
+        if (hasBackgroundDrawable()) {
+            drawBackgroundDrawable(canvas)
+        }
+
         shadow?.draw(canvas, outlinePath)
 
         if (hasStroke()) {
             drawStrokeShape(canvas)
         }
 
-        fillPaint.alpha = prevAlpha
+        drawableState.backgroundDrawable?.alpha = prevBackgroundAlpha
+        fillPaint.alpha = prevFillAlpha
         strokePaint.alpha = prevStrokeAlpha
+    }
+
+    private fun drawBackgroundDrawable(canvas: Canvas) {
+        drawableState.backgroundDrawable?.let { drawable ->
+
+            val rect = RectF()
+            outlinePath.computeBounds(rect, true)
+            val bitmap = drawable.clipToPath(rect)
+
+            val roundBitmap = when (drawableState.shapeAppearanceModel.getCornerFamily()) {
+                CornerFamily.OVAL -> {
+                    bitmap.clipToRadius(bitmap.height / 2f)
+                }
+                else -> {
+                    val cornerSize = drawableState.shapeAppearanceModel.getCornerSize()
+                    bitmap.clipToRadius(cornerSize)
+                }
+            }
+
+            canvas.drawBitmap(roundBitmap, rect.left, rect.top, null)
+        }
     }
 
     private fun drawFillShape(canvas: Canvas) {
@@ -376,6 +422,7 @@ class NeumorphShapeDrawable : Drawable {
         var inEditMode: Boolean = false
 
         var inset: Rect = Rect()
+        var backgroundDrawable: Drawable? = null
         var fillColor: ColorStateList? = null
         var strokeColor: ColorStateList? = null
         var strokeWidth = 0f
@@ -404,6 +451,7 @@ class NeumorphShapeDrawable : Drawable {
             blurProvider = orig.blurProvider
             inEditMode = orig.inEditMode
             inset = Rect(orig.inset)
+            backgroundDrawable = orig.backgroundDrawable
             fillColor = orig.fillColor
             strokeColor = orig.strokeColor
             strokeWidth = orig.strokeWidth
@@ -434,5 +482,6 @@ class NeumorphShapeDrawable : Drawable {
             val scale = alpha + (alpha ushr 7) // convert to 0..256
             return paintAlpha * scale ushr 8
         }
+
     }
 }

--- a/neumorphism/src/main/java/soup/neumorphism/internal/util/BitmapUtils.kt
+++ b/neumorphism/src/main/java/soup/neumorphism/internal/util/BitmapUtils.kt
@@ -1,0 +1,30 @@
+package soup.neumorphism.internal.util
+
+import android.graphics.*
+import android.graphics.drawable.Drawable
+
+object BitmapUtils {
+
+    fun Drawable.clipToPath(rect: RectF): Bitmap {
+        val output = Bitmap.createBitmap(rect.width().toInt(), rect.height().toInt(), Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(output)
+        this.setBounds(0, 0, canvas.width, canvas.height)
+        this.draw(canvas)
+        return output
+    }
+
+    fun Bitmap.clipToRadius(radius: Float): Bitmap {
+        val output = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(output)
+        val paint = Paint()
+        val rect = Rect(0, 0, width, height)
+        val rectF = RectF(rect)
+        paint.isAntiAlias = true
+        canvas.drawARGB(0, 0, 0, 0)
+        canvas.drawRoundRect(rectF, radius, radius, paint)
+        paint.xfermode = PorterDuffXfermode(PorterDuff.Mode.SRC_IN)
+        canvas.drawBitmap(this, rect, rect, paint)
+        return output
+    }
+
+}

--- a/neumorphism/src/main/res/values/attrs.xml
+++ b/neumorphism/src/main/res/values/attrs.xml
@@ -4,6 +4,7 @@
     <attr name="colorShadowLight" format="color"/>
     <attr name="colorShadowDark" format="color"/>
 
+    <attr name="neumorph_backgroundDrawable" format="reference"/>
     <attr name="neumorph_backgroundColor" format="color" />
     <attr name="neumorph_strokeColor" format="color" />
     <attr name="neumorph_strokeWidth" format="dimension" />
@@ -37,6 +38,7 @@
         <attr name="neumorph_shadowColorLight" />
         <attr name="neumorph_shadowColorDark" />
         <attr name="neumorph_shapeAppearance" />
+        <attr name="neumorph_backgroundDrawable" />
     </declare-styleable>
 
     <attr name="neumorphCardViewStyle" format="reference" />
@@ -54,6 +56,7 @@
         <attr name="neumorph_shadowColorLight" />
         <attr name="neumorph_shadowColorDark" />
         <attr name="neumorph_shapeAppearance" />
+        <attr name="neumorph_backgroundDrawable" />
     </declare-styleable>
 
     <attr name="neumorphFloatingActionButtonStyle" format="reference" />
@@ -71,6 +74,7 @@
         <attr name="neumorph_shadowColorLight" />
         <attr name="neumorph_shadowColorDark" />
         <attr name="neumorph_shapeAppearance" />
+        <attr name="neumorph_backgroundDrawable" />
     </declare-styleable>
 
     <attr name="neumorphImageViewStyle" format="reference" />
@@ -88,6 +92,7 @@
         <attr name="neumorph_shadowColorLight" />
         <attr name="neumorph_shadowColorDark" />
         <attr name="neumorph_shapeAppearance" />
+        <attr name="neumorph_backgroundDrawable" />
     </declare-styleable>
 
     <attr name="neumorphImageButtonStyle" format="reference" />
@@ -105,6 +110,7 @@
         <attr name="neumorph_shadowColorLight" />
         <attr name="neumorph_shadowColorDark" />
         <attr name="neumorph_shapeAppearance" />
+        <attr name="neumorph_backgroundDrawable" />
     </declare-styleable>
 
     <attr name="neumorphTextViewStyle" format="reference" />

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -51,7 +51,29 @@
         android:layout_marginTop="48dp"
         app:layout_constraintEnd_toStartOf="@id/pressed_card"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/textview" />
+        app:layout_constraintTop_toBottomOf="@id/textview" >
+
+
+    </soup.neumorphism.NeumorphCardView>
+
+    <soup.neumorphism.NeumorphCardView
+        android:id="@+id/neumorphCardView"
+        style="@style/Widget.Neumorph.CardView"
+        android:layout_width="150dp"
+        android:layout_height="150dp"
+        app:layout_constraintStart_toStartOf="@+id/flat_image_view"
+        app:layout_constraintTop_toBottomOf="@+id/pressed_image_view"
+        app:neumorph_backgroundDrawable="@drawable/gradation" />
+
+    <soup.neumorphism.NeumorphCardView
+        style="@style/Widget.Neumorph.CardView"
+        android:layout_width="150dp"
+        android:layout_height="150dp"
+        app:neumorph_shapeType="pressed"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/neumorphCardView"
+        app:layout_constraintTop_toBottomOf="@+id/pressed_image_view"
+        app:neumorph_backgroundDrawable="@drawable/gradation" />
 
     <soup.neumorphism.NeumorphCardView
         android:id="@+id/pressed_card"
@@ -120,6 +142,17 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
 
+    <soup.neumorphism.NeumorphButton
+        style="@style/Widget.Neumorph.Button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="36dp"
+        android:text="Button"
+        app:neumorph_backgroundDrawable="@drawable/gradation"        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/button"
+        app:layout_constraintHorizontal_bias="0.862"
+        app:layout_constraintStart_toStartOf="parent" />
+
     <soup.neumorphism.NeumorphFloatingActionButton
         android:id="@+id/fab"
         style="@style/Widget.Neumorph.FloatingActionButton"
@@ -131,5 +164,6 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:neumorph_shapeAppearance="@style/CustomShapeAppearance" />
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Drawables can be referenced through this attribute: `neumorph_backgroundDrawable`
Drawables are clipped depending on the selected shape

Examples were added to the sample app at: `activity_main.xml` using the current available drawable: `@drawable/gradation`